### PR TITLE
Use react-app-rewired instead of react-scripts

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,5 +1,4 @@
-const { override, addBabelPlugins } = require('customize-cra')
-const { addReactRefresh } = require('customize-cra-react-refresh')
+const {override, addBabelPlugins} = require('customize-cra')
 const plugin = require('@ui-devtools/tailwind/babel')
 
-module.exports = override(...addBabelPlugins(plugin), addReactRefresh())
+module.exports = override(...addBabelPlugins(plugin))

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "npm run watch:css && react-scripts start",
-    "build": "npm run watch:css && react-scripts build",
+    "start": "npm run watch:css && react-app-rewired start",
+    "build": "npm run watch:css && react-app-rewired build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "watch:css": "postcss src/assets/tailwind.css -o src/assets/main.css"


### PR DESCRIPTION
Alrighty, so this is what I found

0. Installed with yarn, it was a clean install - no problems

1. The babel plugin wasn't actually used because you have to use `react-app-rewired` instead of `react-scripts` to pick up the config overrides you added.

```diff
- "start": "npm run watch:css && react-scripts start",
+ "start": "npm run watch:css && react-app-rewired start",
```

2. There was a duplicate entry for React refresh, I think because create-react-app now adds it by default 🎉 so I removed it from the config overrides.

3. I should really detect if the plugin wasn't set property and give a warning in the devtools

Hope this is helpful!

